### PR TITLE
Removed optimization from transform return

### DIFF
--- a/lua/POSTGrammar.tg
+++ b/lua/POSTGrammar.tg
@@ -716,10 +716,6 @@ transform return (PAST;Op) :language('PIR') {
     unless $I0 goto L3
     if arglist goto L4
     $P0.'pirop'('tailcall')
-    # remove useless new LuaNil
-    $P1 = cpost.'pop'()
-    $P2 = cpost.'pop'()
-    cpost.'push'($P1)
     .return (ops)
   L4:
     $S1 = '(' . $S0

--- a/lua/lib/luaaux.pir
+++ b/lua/lib/luaaux.pir
@@ -597,7 +597,7 @@ messages and in debug information.
     unless $S0 == "\033Lua" goto L2
     .tailcall undump(data, chunkname)
   L2:
-    $I0 = find_encoding 'ascii'
+    $I0 = find_encoding 'utf8'
     $S0 = trans_encoding data, $I0
     .tailcall parser($S0, chunkname)
 .end

--- a/luap.pir
+++ b/luap.pir
@@ -24,7 +24,7 @@ with the standard interface of PCT::HLLCompiler.
     $P0 = compreg 'lua'
     $S0 = "Compiler Lua 5.1 on Parrot  Copyright (C) 2005-2009, Parrot Foundation.\n"
     $P0.'commandline_banner'($S0)
-    $P0.'command_line'(args)
+    $P0.'command_line'(args, 'encoding'=>'utf8')
 .end
 
 =head1 AUTHOR


### PR DESCRIPTION
This is a one-commit fix removes an optimization that breaks some specially crafted tables. I wasn't
sure how to correct it without removing it.

---

This optimization would normally remove an unnecessary variable, such as
the one in the following generated PIR:

set $P18, $P17[k_Foo]
new $P19, "LuaNil"
.tailcall $P18()

In the above snippet, $P19 is not used, so it can be removed without
harm. However, there are instances where this variable is used. Consider
the following code:

function Foo()
    return 42
end

return { Foo() }

In this case, the following PIR should be generated:

new $P21, "LuaNil"
($P21 :slurpy) = $P20()
.tailcall tconstruct($P18, $P19, $P21 :flat)

In this case, the register that initially contains a nil value is
actually used, so it cannot be optimized away.
